### PR TITLE
Support setting radix for Float string operations

### DIFF
--- a/src/integer.ts
+++ b/src/integer.ts
@@ -1,7 +1,7 @@
 import type { GMPFunctions } from './functions';
 import { Float } from './float';
 import { Rational } from './rational';
-import { assertArray, assertInt32, assertUint32 } from './util';
+import {assertArray, assertInt32, assertUint32, assertValidRadix} from './util';
 
 const decoder = new TextDecoder();
 
@@ -569,9 +569,7 @@ export function getIntegerContext(gmp: GMPFunctions, ctx: any) {
     if (num === undefined) {
       gmp.mpz_init(instance.mpz_t);
     } else if (typeof num === 'string') {
-      if (!Number.isSafeInteger(radix) || radix < 2 || radix > 36) {
-        throw new Error('radix must have a value between 2 and 36');
-      }
+      assertValidRadix(radix);
       const strPtr = gmp.malloc_cstr(num);
       const res = gmp.mpz_init_set_str(instance.mpz_t, strPtr, radix);
       gmp.free(strPtr);

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,3 +23,13 @@ export function assertArray(arr: any[]) {
     throw new Error('Invalid parameter specified. Array is required!');
   }
 }
+
+export function isValidRadix(radix: number) {
+  return Number.isSafeInteger(radix) && radix >= 2 && radix <= 36;
+}
+
+export function assertValidRadix(radix: number) {
+  if (!isValidRadix(radix)) {
+    throw new Error('radix must have a value between 2 and 36');
+  }
+}


### PR DESCRIPTION
First of all wanted to say thanks for this great project! 

I noticed an option to set custom radix for parsing or outputting strings is currently missing from the Float wrapper, while it's supported in MPFR API and in the Integer wrapper as well, so I've made a PR to propagate it here.