### PR TITLE
Fix uninitialized usage of mpz_t

### DIFF
--- a/src/integer.ts
+++ b/src/integer.ts
@@ -585,14 +585,17 @@ export function getIntegerContext(gmp: GMPFunctions, ctx: any) {
       if (!(num instanceof Uint8Array)) {
         throw new Error('Only Uint8Array is supported!');
       }
+      gmp.mpz_init(instance.mpz_t);
       const wasmBufPtr = gmp.malloc(num.length);
       gmp.mem.set(num, wasmBufPtr);
       gmp.mpz_import(instance.mpz_t, num.length, 1, 1, 1, 0, wasmBufPtr);
       gmp.free(wasmBufPtr);
     } else if (isRational(num)) {
+      gmp.mpz_init(instance.mpz_t);
       const f = ctx.floatContext.Float(num);
       gmp.mpfr_get_z(instance.mpz_t, f.mpfr_t, 0);
     } else if (isFloat(num)) {
+      gmp.mpz_init(instance.mpz_t);
       gmp.mpfr_get_z(instance.mpz_t, (num as Float).mpfr_t, (num as Float).rndMode);
     } else {
       gmp.mpz_t_free(instance.mpz_t);

--- a/test/Integer.test.ts
+++ b/test/Integer.test.ts
@@ -446,6 +446,7 @@ test('init from Float', () => {
   compare(ctx.Integer(ctx.Float('-1.50')), '-2');
   compare(ctx.Integer(ctx.Float('1.49')), '1');
   compare(ctx.Integer(ctx.Float('1.50')), '2');
+  compare(ctx.Integer(ctx.Float('1.11111111')), '1');
 });
 
 test('toString()', () => {


### PR DESCRIPTION
I saw `Float.toFixed()` [crash](https://runkit.com/embed/h5ifl0fsu3sl) on some inputs, after digging down this seems to be caused by writing into an uninitialized `mpz_t` on conversion. 
An example in [GMP docs](https://gmplib.org/manual/Integer-Import-and-Export) suggests `mpz_t` needs to be initialized before `mpz_import` calls as well.